### PR TITLE
BUG Fix case comparison for paper pages

### DIFF
--- a/src/Page/Paper/Paper_.elm
+++ b/src/Page/Paper/Paper_.elm
@@ -63,7 +63,7 @@ page = Page.prerender
         , data = \routeParams ->
                 BDBLab.papers
                     |> DataSource.andThen (\ms ->
-                        case List.Extra.find (\p -> toRoute p == routeParams) ms of
+                        case List.Extra.find (\p -> String.toLower p.slug == String.toLower routeParams.paper) ms of
                             Just p -> DataSource.succeed p
                             Nothing -> DataSource.fail "Unknown paper??")
                     |> (DataSource.map2 Data BDBLab.members)


### PR DESCRIPTION
Same as 0564d7516e3b4ae1a1fc064d92bfa019cef44729, but for Paper